### PR TITLE
Removing unused parameter in VerifyContent; expected root should be c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ func main() {
   log.Println("Verify Tree: ", vt)
 
   //Verify a specific content in in the tree
-  vc, err := t.VerifyContent(t.MerkleRoot(), list[0])
+  vc, err := t.VerifyContent(list[0])
   if err != nil {
     log.Fatal(err)
   }

--- a/merkle_tree.go
+++ b/merkle_tree.go
@@ -208,7 +208,7 @@ func (m *MerkleTree) VerifyTree() (bool, error) {
 //VerifyContent indicates whether a given content is in the tree and the hashes are valid for that content.
 //Returns true if the expected Merkle Root is equivalent to the Merkle root calculated on the critical path
 //for a given content. Returns true if valid and false otherwise.
-func (m *MerkleTree) VerifyContent(expectedMerkleRoot []byte, content Content) (bool, error) {
+func (m *MerkleTree) VerifyContent(content Content) (bool, error) {
 	for _, l := range m.Leafs {
 		ok, err := l.C.Equals(content)
 		if err != nil {

--- a/merkle_tree_test.go
+++ b/merkle_tree_test.go
@@ -235,7 +235,7 @@ func TestMerkleTree_VerifyContent(t *testing.T) {
 			t.Error("error: unexpected error:  ", err)
 		}
 		if len(table[i].contents) > 0 {
-			v, err := tree.VerifyContent(tree.MerkleRoot(), table[i].contents[0])
+			v, err := tree.VerifyContent(table[i].contents[0])
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -244,7 +244,7 @@ func TestMerkleTree_VerifyContent(t *testing.T) {
 			}
 		}
 		if len(table[i].contents) > 1 {
-			v, err := tree.VerifyContent(tree.MerkleRoot(), table[i].contents[1])
+			v, err := tree.VerifyContent(table[i].contents[1])
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -253,7 +253,7 @@ func TestMerkleTree_VerifyContent(t *testing.T) {
 			}
 		}
 		if len(table[i].contents) > 2 {
-			v, err := tree.VerifyContent(tree.MerkleRoot(), table[i].contents[2])
+			v, err := tree.VerifyContent(table[i].contents[2])
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -264,7 +264,7 @@ func TestMerkleTree_VerifyContent(t *testing.T) {
 		if len(table[i].contents) > 0 {
 			tree.Root.Hash = []byte{1}
 			tree.merkleRoot = []byte{1}
-			v, err := tree.VerifyContent(tree.MerkleRoot(), table[i].contents[0])
+			v, err := tree.VerifyContent(table[i].contents[0])
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -275,7 +275,7 @@ func TestMerkleTree_VerifyContent(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		v, err := tree.VerifyContent(tree.MerkleRoot(), TestContent{x: "NotInTestTable"})
+		v, err := tree.VerifyContent(TestContent{x: "NotInTestTable"})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
…ompared against trees root value.

Closes #3